### PR TITLE
QA-3961 Check whether more limited nodetype than "nt:base" on query f…

### DIFF
--- a/src/main/java/org/jahia/modules/facets/initializers/FacetsChoiceListInitializers.java
+++ b/src/main/java/org/jahia/modules/facets/initializers/FacetsChoiceListInitializers.java
@@ -119,7 +119,18 @@ public class FacetsChoiceListInitializers implements ModuleChoiceListInitializer
             }
         }
 
-        if (parentNode != null && parentNode.hasProperty("j:bindedComponent")) {
+        if (parentNode != null && parentNode.hasProperty("j:type")) {
+            Value[] values1 = new Value[] { parentNode.getProperty("j:type").getValue() };
+            ExtendedPropertyDefinition[] propertyDefs = ComponentLinkerChoiceListInitializer.getCommonChildNodeDefinitions(values1,
+                    true, true, new LinkedHashSet<String>());
+            for (ExtendedPropertyDefinition def : propertyDefs) {
+                if ((!hierarchical || def.isHierarchical())
+                        && (requiredType == PropertyType.UNDEFINED || def
+                        .getRequiredType() == requiredType) && !def.isHidden() ) {
+                    propDefs.add(def);
+                }
+            }
+        } else if (parentNode != null && parentNode.hasProperty("j:bindedComponent")) {
             JCRNodeWrapper boundNode = (JCRNodeWrapper) parentNode.getProperty("j:bindedComponent").getNode();
             if (boundNode.hasProperty("j:allowedTypes")) {
                 final Value[] values1 = boundNode.getProperty("j:allowedTypes").getValues();
@@ -128,7 +139,7 @@ public class FacetsChoiceListInitializers implements ModuleChoiceListInitializer
                 for (ExtendedPropertyDefinition def : propertyDefs) {
                     if ((!hierarchical || def.isHierarchical())
                             && (requiredType == PropertyType.UNDEFINED || def
-                                    .getRequiredType() == requiredType)) {
+                                    .getRequiredType() == requiredType) && !def.isHidden() ) {
                         propDefs.add(def);
                     }                    
                 }
@@ -144,7 +155,7 @@ public class FacetsChoiceListInitializers implements ModuleChoiceListInitializer
                     ExtendedPropertyDefinition ep = (ExtendedPropertyDefinition) def;
                     if ((!hierarchical || ep.isHierarchical())
                             && (requiredType == PropertyType.UNDEFINED || ep
-                                    .getRequiredType() == requiredType)) {
+                                    .getRequiredType() == requiredType) && !ep.isHidden()) {
                         propDefs.add(ep);
                     }
                 }

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -5,7 +5,7 @@
 [jnt:facets] > jnt:content, jmix:queryContent, jmix:bindedComponent
 orderable
 - j:bindedComponent (weakreference)
-- j:type (string, choicelist[subnodetypes = 'jnt:file,jnt:folder,nt:hierarchyNode,jnt:page,jnt:content,jmix:basicContent,jmix:editorialContent,jmix:retrievableContent,jmix:searchable',resourceBundle]) indexed=no mandatory
+- j:type (string, choicelist[subnodetypes = 'jnt:file,jnt:folder,nt:hierarchyNode,jnt:page,jnt:content,jmix:basicContent,jmix:editorialContent,jmix:retrievableContent,jmix:searchable,jmix:tagged',resourceBundle]) indexed=no mandatory
 + * (jnt:facet)
 
 [jnt:facet] > jnt:content abstract

--- a/src/main/resources/jnt_facets/html/activeFacets.jspf
+++ b/src/main/resources/jnt_facets/html/activeFacets.jspf
@@ -24,6 +24,7 @@
         <c:set var="facetParam" value="${facet:getDeleteFacetUrl2(facetValue, activeFacetsVars[facetParamVarName])}"/>
         <c:url var="facetUrl" value="${url.mainResource}">
             <c:if test="${not empty facetParam}">
+                <c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
                 <c:param name="${facetParamVarName}" value="${functions:encodeUrlParam(facetParam)}"/>
             </c:if>
         </c:url>

--- a/src/main/resources/jnt_facets/html/facetDisplay.jspf
+++ b/src/main/resources/jnt_facets/html/facetDisplay.jspf
@@ -20,6 +20,7 @@
 		<c:forEach items="${currentFacet.values}" var="facetValue">
 			<c:if test="${not facet:isFacetValueApplied(facetValue, activeFacetsVars[activeFacetMapVarName])}">
 				<c:url var="facetUrl" value="${url.mainResource}">
+					<c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
 					<c:param name="${facetParamVarName}" value="${functions:encodeUrlParam(facet:getFacetDrillDownUrl(facetValue, activeFacetsVars[facetParamVarName]))}"/>
 				</c:url>
 				<li><a href="${facetUrl}" rel="nofollow">

--- a/src/main/resources/jnt_facets/html/facets.javascripttagcloud.jsp
+++ b/src/main/resources/jnt_facets/html/facets.javascripttagcloud.jsp
@@ -22,8 +22,10 @@
 <c:set var="boundComponent"
        value="${uiComponents:getBindedComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
 <template:addCacheDependency node="${boundComponent}"/>
+<jcr:nodeProperty var="facetListNodeType" node="${currentNode}" name="j:type" />
 <c:if test="${not empty boundComponent}">
     <c:set var="facetParamVarName" value="N-${boundComponent.name}"/>
+    <c:set var="facetTargetTypeName" value="N-type-${boundComponent.name}"/>
     <c:set var="activeFacetMapVarName" value="afm-${boundComponent.name}"/>
     <c:if test="${not empty param[facetParamVarName] and empty activeFacetsVars[facetParamVarName]}">
         <c:if test="${activeFacetsVars == null}">
@@ -71,6 +73,7 @@
                         var word_list = new Array(<c:forEach items="${currentFacet.values}" var="facetValue" varStatus="status">
                                 <c:if test="${not facet:isFacetValueApplied(facetValue, activeFacetsVars[activeFacetMapVarName])}">
                                 <c:url var="facetUrl" value="${url.mainResource}">
+                                <c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
                                 <c:param name="${facetParamVarName}"
                                value="${functions:encodeUrlParam(facet:getFacetDrillDownUrl(facetValue, activeFacetsVars[facetParamVarName]))}"/>
                                 </c:url>

--- a/src/main/resources/jnt_facets/html/facets.jsp
+++ b/src/main/resources/jnt_facets/html/facets.jsp
@@ -18,8 +18,10 @@
 <%--@elvariable id="acl" type="java.lang.String"--%>
 <template:addResources type="css" resources="facets.css"/>
 <c:set var="boundComponent" value="${uiComponents:getBindedComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
+<jcr:nodeProperty var="facetListNodeType" node="${currentNode}" name="j:type" />
 <c:if test="${not empty boundComponent}">
     <c:set var="facetParamVarName" value="N-${boundComponent.name}"/>
+    <c:set var="facetTargetTypeName" value="N-type-${boundComponent.name}"/>
     <c:set var="activeFacetMapVarName" value="afm-${boundComponent.name}"/>
     <c:if test="${not empty param[facetParamVarName] and empty activeFacetsVars[facetParamVarName]}">
         <c:if test="${activeFacetsVars == null}">
@@ -38,6 +40,7 @@
 
     <template:option node="${boundComponent}" nodetype="${boundComponent.primaryNodeTypeName},jmix:list" view="hidden.load">
         <template:param name="queryLoadAllUnsorted" value="true"/>
+        <template:param name="facetListNodeType" value="${facetListNodeType}" />
     </template:option>
 
     <facet:setupQueryAndMetadata var="listQuery" boundComponent="${boundComponent}" existingQuery="${moduleMap.listQuery}"
@@ -75,6 +78,7 @@
             <c:if test="${not facet:isFacetValueApplied(facetValue, activeFacetsVars[activeFacetMapVarName])}">
                 <c:set var="facetDrillDownUrl" value="${facet:getFacetDrillDownUrl(facetValue, activeFacetsVars[facetParamVarName])}"/>
                 <c:url var="facetUrl" value="${url.mainResource}">
+                    <c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
                     <c:param name="${facetParamVarName}" value="${functions:encodeUrlParam(facetDrillDownUrl)}"/>
                 </c:url>
                 <li><a href="${facetUrl}"><facet:facetValueLabel currentActiveFacetValue="${facetValue}" facetValueLabels="${facetValueLabels}"/></a>

--- a/src/main/resources/jnt_facets/html/facets.tagcloud.jsp
+++ b/src/main/resources/jnt_facets/html/facets.tagcloud.jsp
@@ -20,8 +20,10 @@
 <template:addResources type="css" resources="tags.css"/>
 <c:set var="boundComponent"
        value="${uiComponents:getBindedComponent(currentNode, renderContext, 'j:bindedComponent')}"/>
+<jcr:nodeProperty var="facetListNodeType" node="${currentNode}" name="j:type" />
 <c:if test="${not empty boundComponent}">
     <c:set var="facetParamVarName" value="N-${boundComponent.name}"/>
+    <c:set var="facetTargetTypeName" value="N-type-${boundComponent.name}"/>
     <c:set var="activeFacetMapVarName" value="afm-${boundComponent.name}"/>
     <c:if test="${not empty param[facetParamVarName] and empty activeFacetsVars[facetParamVarName]}">
         <c:if test="${activeFacetsVars == null}">
@@ -69,6 +71,7 @@
                         <c:forEach items="${currentFacet.values}" var="facetValue">
                             <c:if test="${not facet:isFacetValueApplied(facetValue, activeFacetsVars[activeFacetMapVarName])}">
                                 <c:url var="facetUrl" value="${url.mainResource}">
+                                    <c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
                                     <c:param name="${facetParamVarName}"
                                              value="${functions:encodeUrlParam(facet:getFacetDrillDownUrl(facetValue, activeFacetsVars[facetParamVarName]))}"/>
                                 </c:url>

--- a/src/main/resources/jnt_facets/html/rangeFacetDisplay.jspf
+++ b/src/main/resources/jnt_facets/html/rangeFacetDisplay.jspf
@@ -20,6 +20,7 @@
 		<c:forEach items="${currentFacet.counts}" var="facetValue">
 			<c:if test="${not facet:isFacetValueApplied(facetValue, activeFacetsVars[activeFacetMapVarName])}">
 				<c:url var="facetUrl" value="${url.mainResource}">
+					<c:param name="${facetTargetTypeName}" value="${functions:encodeUrlParam(facetListNodeType)}" />
 					<c:param name="${facetParamVarName}" value="${functions:encodeUrlParam(facet:getFacetDrillDownUrl(facetValue, activeFacetsVars[facetParamVarName]))}"/>
 				</c:url>
 				<li><a href="${facetUrl}" rel="nofollow">


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-3961

## Description

These modification contain the following changes:
- The j:type property is used to determine the type to use instead of nt:base. If it cannot be properly resolved (for example because forked JSPs have not been updated) it will fallback to nt:base
- The FacetChoiceListInitializer has been improved to display only the properties for the j:type selected in the facet list. Also, hidden properties will no longer be displayed.
- Facet URL generation was modified to add a N-type-NODENAME URL query parameter that encodes the j:type value so that the list query may behave properly. This change requires updating forked JSP.
- The jmix:tagged type was added to the list of allowed types when selecting a facet type (note: it might be interesting to add more)
- The tag cloud was also improved to replace its usage of nt:base with jmix:tagged. Again, if this JSP was forked in projects it will require updating.


## Checklist

Impact of these changes for QA:
- Re-test all facet-related features (all facet types)
- Re-test tag clouds

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [x] User-facing Documentation
